### PR TITLE
Adding listening port env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ LABEL maintainer="fletchto99"
 ENV \
     CUSTOM_PORT="6080" \
     HOME="/config" \
-    TITLE="Nicotine"
+    TITLE="Nicotine" \
+    LISTENING_PORT="2234"
 
 RUN \
     echo "**** install runtime packages ****" && \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This container is based on LinuxServer's [Docker Baseimage KasmVNC](https://gith
 | Variable | Description |
 | :----: | --- |
 | CUSTOM_PORT | Internal port the container listens on for http if it needs to be swapped from the default 6080. |
+| LISTENING_PORT | Listening Port allows other peers on the network to connect to your client and share files. Default is 2234. |
 | CUSTOM_USER | HTTP Basic auth username, abc is default. |
 | PASSWORD | HTTP Basic auth password, abc is default. If unset there will be no auth |
 | SUBFOLDER | Subfolder for the application if running a subfolder reverse proxy, need both slashes IE `/subfolder/` |

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,1 @@
-/usr/bin/nicotine
+/usr/bin/nicotine --port $LISTENING_PORT


### PR DESCRIPTION
ended up implementing this. 

Tested and passes
closes: https://github.com/fletchto99/nicotine-plus-docker/issues/4