### PR TITLE
Update autostart to add isolated

### DIFF
--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,1 @@
-/usr/bin/nicotine --port $LISTENING_PORT
+/usr/bin/nicotine --isolated --port $LISTENING_PORT


### PR DESCRIPTION
adding isolated

# Disables features that require external applications, useful for e.g. Docker containers

Version 3.3.8 (February 24, 2025) has
 * Added isolated mode (`nicotine --isolated`) for standalone environments (e.g. Docker containers)