### PR TITLE
ci: add build provenance attestation for GHCR images

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -98,6 +98,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -159,6 +161,16 @@ jobs:
             $(jq -cr '.tags | map(select(startswith("${{ env.GHCR_REGISTRY }}") | not) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@sha256:%s ' *)
 
-      - name: Inspect image
+      - name: Inspect image and extract digest
+        id: inspect
         run: |
-          docker buildx imagetools inspect ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:latest
+          digest=$(docker buildx imagetools inspect ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:latest --format '{{printf "%s" .Manifest.Digest}}')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "Manifest digest: $digest"
+
+      - name: Attest GHCR image
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}
+          subject-digest: ${{ steps.inspect.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Adds [SLSA build provenance](https://slsa.dev/) attestation to the publish workflow using `actions/attest-build-provenance@v4.1.0`.

## Changes
- Added `id-token: write` and `attestations: write` permissions to the `merge` job
- Replaced the `Inspect image` step with `Inspect image and extract digest` to capture the multi-arch manifest digest
- Added an `Attest GHCR image` step that generates and pushes provenance to the GHCR registry

## Why the merge job?
Since this repo uses a split build/merge pattern with per-platform base images, the attestation targets the **final manifest list digest** (not individual platform images), so consumers verify the multi-arch image they actually pull.

## Verification
After merging, consumers can verify with:
```bash
gh attestation verify oci://ghcr.io/fletchto99/nicotine-plus-docker:latest --owner fletchto99
```