### PR TITLE
Reorder tags so latest appears first in registry UI

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -145,7 +145,6 @@ jobs:
           tags: |
             type=raw,value=${{ steps.get_version.outputs.VERSION }}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value={{date 'YYYYMMDD'}}-{{sha}},enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.title=${{ github.repository }}
             org.opencontainers.image.description=Multi-architecture container image


### PR DESCRIPTION
Registries sort by push time. Moving `latest` to the end of the tag list ensures it's pushed last and appears first in GHCR/Docker Hub.