### PR TITLE
Add weekly GHCR cleanup workflow

### DIFF
--- a/.github/workflows/cleanup_ghcr.yml
+++ b/.github/workflows/cleanup_ghcr.yml
@@ -1,0 +1,18 @@
+name: Cleanup GHCR
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Weekly on Monday at 6:00 UTC
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete orphaned images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          delete-orphaned-images: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a scheduled workflow to prune GHCR images weekly (Monday 6AM UTC):

- Deletes orphaned (untagged) images that aren't referenced by any manifest list
- Uses [dataaxiom/ghcr-cleanup-action](https://github.com/dataaxiom/ghcr-cleanup-action) which is multi-arch aware
- Can also be triggered manually via workflow_dispatch

Docker Hub is not included as it has built-in inactive image retention policies.