### PR TITLE
Pin ghcr-cleanup-action to SHA

### DIFF
--- a/.github/workflows/cleanup_ghcr.yml
+++ b/.github/workflows/cleanup_ghcr.yml
@@ -12,7 +12,7 @@ jobs:
       packages: write
     steps:
       - name: Delete orphaned images
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1
         with:
           delete-orphaned-images: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pins `dataaxiom/ghcr-cleanup-action` to commit SHA for supply chain security. All other actions were already pinned.