### PR TITLE
Add per-platform tags and OCI manifest annotations

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -162,10 +162,10 @@ jobs:
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
           ANNOTATIONS=(
-            --annotation "manifest:org.opencontainers.image.title=${{ github.event.repository.name }}"
-            --annotation "manifest:org.opencontainers.image.description=${{ github.event.repository.description }}"
-            --annotation "manifest:org.opencontainers.image.source=https://github.com/${{ github.repository }}"
-            --annotation "manifest:org.opencontainers.image.vendor=${{ github.repository_owner }}"
+            --annotation "org.opencontainers.image.title=${{ github.event.repository.name }}"
+            --annotation "org.opencontainers.image.description=${{ github.event.repository.description }}"
+            --annotation "org.opencontainers.image.source=https://github.com/${{ github.repository }}"
+            --annotation "org.opencontainers.image.vendor=${{ github.repository_owner }}"
           )
           docker buildx imagetools create --prefer-index=false "${ANNOTATIONS[@]}" \
             -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:amd64-${VERSION} \
@@ -180,10 +180,10 @@ jobs:
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
           ANNOTATIONS=(
-            --annotation "manifest:org.opencontainers.image.title=${{ github.event.repository.name }}"
-            --annotation "manifest:org.opencontainers.image.description=${{ github.event.repository.description }}"
-            --annotation "manifest:org.opencontainers.image.source=https://github.com/${{ github.repository }}"
-            --annotation "manifest:org.opencontainers.image.vendor=${{ github.repository_owner }}"
+            --annotation "org.opencontainers.image.title=${{ github.event.repository.name }}"
+            --annotation "org.opencontainers.image.description=${{ github.event.repository.description }}"
+            --annotation "org.opencontainers.image.source=https://github.com/${{ github.repository }}"
+            --annotation "org.opencontainers.image.vendor=${{ github.repository_owner }}"
           )
           docker buildx imagetools create --prefer-index=false "${ANNOTATIONS[@]}" \
             -t ${{ env.DOCKERHUB_IMAGE_NAME }}:amd64-${VERSION} \

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          name: digest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -116,8 +116,8 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
+          pattern: digest-*
+          merge-multiple: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -150,19 +150,59 @@ jobs:
             org.opencontainers.image.description=Multi-architecture container image
             org.opencontainers.image.vendor=${{ github.repository_owner }}
 
+      - name: Resolve digests
+        id: digests
+        run: |
+          AMD64_DIGEST="sha256:$(ls /tmp/digests/digest-amd64/)"
+          ARM64_DIGEST="sha256:$(ls /tmp/digests/digest-arm64/)"
+          echo "amd64=$AMD64_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "arm64=$ARM64_DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Tag per-platform images (GHCR)
+        run: |
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          docker buildx imagetools create --prefer-index=false \
+            -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:amd64-${VERSION} \
+            -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:amd64-latest \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.amd64 }}
+          docker buildx imagetools create --prefer-index=false \
+            -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:arm64-${VERSION} \
+            -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:arm64-latest \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.arm64 }}
+
+      - name: Tag per-platform images (Docker Hub)
+        run: |
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          docker buildx imagetools create --prefer-index=false \
+            -t ${{ env.DOCKERHUB_IMAGE_NAME }}:amd64-${VERSION} \
+            -t ${{ env.DOCKERHUB_IMAGE_NAME }}:amd64-latest \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.amd64 }}
+          docker buildx imagetools create --prefer-index=false \
+            -t ${{ env.DOCKERHUB_IMAGE_NAME }}:arm64-${VERSION} \
+            -t ${{ env.DOCKERHUB_IMAGE_NAME }}:arm64-latest \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.arm64 }}
+
       - name: Create manifest list and push (GHCR)
-        working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map(select(startswith("${{ env.GHCR_REGISTRY }}")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@sha256:%s ' *)
+            --annotation "index:org.opencontainers.image.title=${{ github.event.repository.name }}" \
+            --annotation "index:org.opencontainers.image.description=${{ github.event.repository.description }}" \
+            --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --annotation "index:org.opencontainers.image.vendor=${{ github.repository_owner }}" \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.amd64 }} \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.arm64 }}
 
       - name: Create manifest list and push (Docker Hub)
-        working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map(select(startswith("${{ env.GHCR_REGISTRY }}") | not) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@sha256:%s ' *)
+            --annotation "index:org.opencontainers.image.title=${{ github.event.repository.name }}" \
+            --annotation "index:org.opencontainers.image.description=${{ github.event.repository.description }}" \
+            --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --annotation "index:org.opencontainers.image.vendor=${{ github.repository_owner }}" \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.amd64 }} \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.arm64 }}
 
       - name: Inspect image and extract digest
         id: inspect

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -161,17 +161,11 @@ jobs:
       - name: Tag per-platform images (GHCR)
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
-          ANNOTATIONS=(
-            --annotation "org.opencontainers.image.title=${{ github.event.repository.name }}"
-            --annotation "org.opencontainers.image.description=${{ github.event.repository.description }}"
-            --annotation "org.opencontainers.image.source=https://github.com/${{ github.repository }}"
-            --annotation "org.opencontainers.image.vendor=${{ github.repository_owner }}"
-          )
-          docker buildx imagetools create --prefer-index=false "${ANNOTATIONS[@]}" \
+          docker buildx imagetools create --prefer-index=false \
             -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:amd64-${VERSION} \
             -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:amd64-latest \
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.amd64 }}
-          docker buildx imagetools create --prefer-index=false "${ANNOTATIONS[@]}" \
+          docker buildx imagetools create --prefer-index=false \
             -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:arm64-${VERSION} \
             -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:arm64-latest \
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.arm64 }}
@@ -179,17 +173,11 @@ jobs:
       - name: Tag per-platform images (Docker Hub)
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
-          ANNOTATIONS=(
-            --annotation "org.opencontainers.image.title=${{ github.event.repository.name }}"
-            --annotation "org.opencontainers.image.description=${{ github.event.repository.description }}"
-            --annotation "org.opencontainers.image.source=https://github.com/${{ github.repository }}"
-            --annotation "org.opencontainers.image.vendor=${{ github.repository_owner }}"
-          )
-          docker buildx imagetools create --prefer-index=false "${ANNOTATIONS[@]}" \
+          docker buildx imagetools create --prefer-index=false \
             -t ${{ env.DOCKERHUB_IMAGE_NAME }}:amd64-${VERSION} \
             -t ${{ env.DOCKERHUB_IMAGE_NAME }}:amd64-latest \
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.amd64 }}
-          docker buildx imagetools create --prefer-index=false "${ANNOTATIONS[@]}" \
+          docker buildx imagetools create --prefer-index=false \
             -t ${{ env.DOCKERHUB_IMAGE_NAME }}:arm64-${VERSION} \
             -t ${{ env.DOCKERHUB_IMAGE_NAME }}:arm64-latest \
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.arm64 }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -161,11 +161,17 @@ jobs:
       - name: Tag per-platform images (GHCR)
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
-          docker buildx imagetools create --prefer-index=false \
+          ANNOTATIONS=(
+            --annotation "manifest:org.opencontainers.image.title=${{ github.event.repository.name }}"
+            --annotation "manifest:org.opencontainers.image.description=${{ github.event.repository.description }}"
+            --annotation "manifest:org.opencontainers.image.source=https://github.com/${{ github.repository }}"
+            --annotation "manifest:org.opencontainers.image.vendor=${{ github.repository_owner }}"
+          )
+          docker buildx imagetools create --prefer-index=false "${ANNOTATIONS[@]}" \
             -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:amd64-${VERSION} \
             -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:amd64-latest \
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.amd64 }}
-          docker buildx imagetools create --prefer-index=false \
+          docker buildx imagetools create --prefer-index=false "${ANNOTATIONS[@]}" \
             -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:arm64-${VERSION} \
             -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:arm64-latest \
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.arm64 }}
@@ -173,11 +179,17 @@ jobs:
       - name: Tag per-platform images (Docker Hub)
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
-          docker buildx imagetools create --prefer-index=false \
+          ANNOTATIONS=(
+            --annotation "manifest:org.opencontainers.image.title=${{ github.event.repository.name }}"
+            --annotation "manifest:org.opencontainers.image.description=${{ github.event.repository.description }}"
+            --annotation "manifest:org.opencontainers.image.source=https://github.com/${{ github.repository }}"
+            --annotation "manifest:org.opencontainers.image.vendor=${{ github.repository_owner }}"
+          )
+          docker buildx imagetools create --prefer-index=false "${ANNOTATIONS[@]}" \
             -t ${{ env.DOCKERHUB_IMAGE_NAME }}:amd64-${VERSION} \
             -t ${{ env.DOCKERHUB_IMAGE_NAME }}:amd64-latest \
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.amd64 }}
-          docker buildx imagetools create --prefer-index=false \
+          docker buildx imagetools create --prefer-index=false "${ANNOTATIONS[@]}" \
             -t ${{ env.DOCKERHUB_IMAGE_NAME }}:arm64-${VERSION} \
             -t ${{ env.DOCKERHUB_IMAGE_NAME }}:arm64-latest \
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.digests.outputs.arm64 }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -30,8 +30,10 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
+            arch: amd64
             base_image: ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
           - platform: linux/arm64
+            arch: arm64
             base_image: ghcr.io/linuxserver/baseimage-selkies:arm64v8-ubuntunoble
     permissions:
       contents: read
@@ -49,8 +51,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-        with:
-          driver: docker-container
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -59,18 +59,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build and Push Docker image
         id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
-          file: Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
           build-args: |
@@ -90,7 +83,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: digest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          name: digest-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -145,10 +138,6 @@ jobs:
           tags: |
             type=raw,value=${{ steps.get_version.outputs.VERSION }}
             type=raw,value=latest,enable={{is_default_branch}}
-          labels: |
-            org.opencontainers.image.title=${{ github.repository }}
-            org.opencontainers.image.description=Multi-architecture container image
-            org.opencontainers.image.vendor=${{ github.repository_owner }}
 
       - name: Resolve digests
         id: digests


### PR DESCRIPTION
Adds per-platform tags and OCI manifest annotations to the existing matrix build + merge workflow.

## Changes
- **Per-platform tags**: `amd64-latest`, `arm64-latest`, `amd64-<version>`, `arm64-<version>`
- **OCI annotations**: Manifest list includes title, description, source, vendor for GHCR package page
- **Manifest list pushed last** so it appears first in registry UI
- Digest resolution changed from merged glob to per-arch artifact directories

## Registry result
```
latest, <version>                    ← multi-arch manifest (first)
arm64-<version>, arm64-latest        ← platform image
amd64-<version>, amd64-latest        ← platform image
```