### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   GHCR_REGISTRY: ghcr.io
   GHCR_IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Potential fix for [https://github.com/fletchto99/nicotine-plus-docker/security/code-scanning/1](https://github.com/fletchto99/nicotine-plus-docker/security/code-scanning/1)

Add an explicit root-level `permissions` block in `.github/workflows/publish_release.yml` so all jobs (including `smoke-test` reusable workflow call jobs) have a constrained default `GITHUB_TOKEN`.  
Best fix without changing behavior: set a minimal default like `contents: read` at workflow root, and retain existing per-job overrides (e.g., `build` keeps `packages: write`). This preserves current functionality while ensuring unannotated jobs no longer inherit potentially broad defaults.

Change location:
- File: `.github/workflows/publish_release.yml`
- Insert directly after the `on:` trigger section (before `env:`), adding:
  - `permissions:`
  - `contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
