### PR TITLE
test: add headless browser check to smoke test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/.github/scripts"
+    schedule:
+      interval: "weekly"

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scripts",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "playwright": "1.59.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nicotine-plus-smoke-test",
+  "private": true,
+  "description": "CI smoke test dependencies for nicotine-plus-docker",
+  "dependencies": {
+    "playwright": "1.59.1"
+  }
+}

--- a/.github/scripts/verify-selkies-ui.js
+++ b/.github/scripts/verify-selkies-ui.js
@@ -1,0 +1,48 @@
+const { chromium } = require('playwright');
+
+const HTTP_URL = process.env.HTTP_URL || 'http://localhost:6080/';
+const HTTPS_URL = process.env.HTTPS_URL || 'https://localhost:6081/';
+
+async function checkPage(browser, url, label, contextOpts = {}) {
+  const errors = [];
+  const logs = [];
+  const context = await browser.newContext(contextOpts);
+  const page = await context.newPage();
+  page.on('console', msg => {
+    logs.push(msg.text());
+    if (msg.type() === 'error' && msg.text().includes('FATAL')) {
+      errors.push(msg.text());
+    }
+  });
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.waitForTimeout(3000);
+  const preflightPassed = logs.some(l => l.includes('Pre-flight checks passed'));
+  const hasSecureContextError = logs.some(l => l.includes('Not in a secure context'));
+  const hasVideoDecoderError = logs.some(l => l.includes('does not support the VideoDecoder'));
+  console.log(`[${label}] Console logs: ${logs.length}, Pre-flight passed: ${preflightPassed}, Secure context error: ${hasSecureContextError}, VideoDecoder error: ${hasVideoDecoderError}, FATAL errors: ${errors.length}`);
+  if (errors.length > 0) {
+    errors.forEach(e => console.error(`  [${label}] ${e}`));
+  }
+  await context.close();
+  if (hasSecureContextError || hasVideoDecoderError || errors.length > 0) {
+    throw new Error(`${label}: Selkies web UI failed to initialize correctly`);
+  }
+  if (!preflightPassed) {
+    throw new Error(`${label}: Selkies pre-flight checks did not pass`);
+  }
+  console.log(`[${label}] Selkies web UI loaded successfully`);
+}
+
+(async () => {
+  const browser = await chromium.launch();
+  try {
+    await checkPage(browser, HTTPS_URL, 'HTTPS', { ignoreHTTPSErrors: true });
+    await checkPage(browser, HTTP_URL, 'HTTP (localhost)');
+  } catch (err) {
+    console.error(`::error::${err.message}`);
+    await browser.close();
+    process.exit(1);
+  }
+  await browser.close();
+  console.log('All browser checks passed');
+})();

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -96,6 +96,13 @@ jobs:
           docker logs smoke-test
           exit 1
 
+      - name: Verify Selkies web UI loads in browser
+        run: |
+          cd .github/scripts
+          npm ci --ignore-scripts > /dev/null 2>&1
+          npx playwright install chromium --with-deps > /dev/null 2>&1
+          node verify-selkies-ui.js
+
       - name: Verify healthcheck status
         run: |
           STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test)


### PR DESCRIPTION
## Summary

Adds a Playwright-based headless browser step to the smoke test that verifies the Selkies web UI actually initializes correctly in a real browser — not just that nginx returns HTTP 200.

## What it checks

- Loads both `https://localhost:6081/` and `http://localhost:6080/` in headless Chromium
- Verifies Selkies pre-flight checks pass (`isSecureContext` + `VideoDecoder` API)
- Detects any `FATAL` console errors
- Fails the build if the JS app doesn't initialize on either protocol

## Why

The existing curl-based check (`curl -sf http://localhost:6080/`) only verifies the server responds with HTTP 200. It would **not** have caught the HTTPS/WebCodecs breaking change from #39, since curl doesn't execute JavaScript. A headless browser test validates the full client-side initialization path.

## Changes

- **`.github/scripts/verify-selkies-ui.js`** — Extracted Playwright test script (configurable via `HTTP_URL`/`HTTPS_URL` env vars for local testing)
- **`.github/scripts/package.json`** / **`package-lock.json`** — Pinned Playwright dependency for reproducible builds
- **`.github/dependabot.yml`** — Added npm ecosystem entry for `/.github/scripts` to keep Playwright updated
- **`smoke_test.yml`** — New step using `npm ci` + extracted script instead of inline heredoc
