### PR TITLE
fix: install librsvg2-common so GTK can render SVG icons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN \
     "https://github.com/nicotine-plus/nicotine-plus/releases/download/${VERSION}/debian-package.zip" && \
   python3 -m zipfile -e /tmp/debian-package.zip /tmp/nicotine && \
   DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    librsvg2-common \
     /tmp/nicotine/*.deb && \
   echo "**** cleanup ****" && \
   printf \


### PR DESCRIPTION
## Summary

Restores rendering of Nicotine+'s in-app icons (toolbar buttons, tray, etc.) which have been broken since `ac860cb`.

## Root cause

Nicotine+ ships GTK icon themes whose icons are **SVGs**. GTK rasterizes them at runtime via the **GdkPixbuf SVG loader**, which lives in the `librsvg2-common` package. Without it, GdkPixbuf silently refuses to load SVGs and the icons render as broken placeholders — no error in the logs.

`librsvg2-common` used to land in the image as a transitive dependency of `librsvg2-bin` (we needed `rsvg-convert` at build time for the selkies app icon). When that build-time dependency was removed in ac860cb in favor of bundling a pre-converted PNG, `librsvg2-common` went with it.

The nicotine+ `.deb` only **Recommends** `librsvg2-common`, and the install line uses `--no-install-recommends`, so it isn't pulled back in automatically. Adding it explicitly is the minimal fix.

## Change

One line added to the existing `apt-get install` invocation:

```dockerfile
DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
    librsvg2-common \
    /tmp/nicotine/*.deb && \
```

## Verification

Confirmed by the issue reporter that installing `librsvg2-common` into the container resolves the broken icons. Not host-OS specific (reporter happened to notice on NixOS, but the package is missing on every host).

Fixes #50